### PR TITLE
:wrench: baseCommand breaks after removing set pipe

### DIFF
--- a/tools/samtools_calmd.cwl
+++ b/tools/samtools_calmd.cwl
@@ -11,7 +11,7 @@ requirements:
     ramMin: 12000
     coresMin: $(inputs.threads)
 
-baseCommand: ["/bin/bash -c"]
+baseCommand: []
 arguments:
   - position: 1
     shellQuote: false


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

After testing this tool in a different PR, having incorporated the requested change of removing set pipe fail command, leaving the baseCommand of /bin/bash -c broke the tool, so I removed it.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Was run within another wf here: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/0a79a22c-ec93-4712-8e96-52351d596047/
- [ ] Test B

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
